### PR TITLE
Update actionlint to v1.7.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"
 
   # Maintain dependencies for Python scripts
   - package-ecosystem: "pip"

--- a/.github/workflows/actionlint.dockerfile
+++ b/.github/workflows/actionlint.dockerfile
@@ -1,0 +1,3 @@
+# Since dependabot cannot update workflows using docker,
+# we use this indirection since dependabot can update this file.
+FROM rhysd/actionlint:1.7.1@sha256:435ecdb63b1169e80ca3e136290072548c07fc4d76a044cf5541021712f8f344

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,11 +7,13 @@ on:
       - "main"
     paths:
       - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*' # This workflow
   pull_request:
     branches:
       - "main"
     paths:
       - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*' # This workflow
 
 env:
   LC_ALL: en_US.UTF-8
@@ -39,11 +41,10 @@ jobs:
           submodules: true
 
       - name: "Download actionlint"
-        id: get_actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/2d26fef7e97b8ab345791f5ade3252da47d083e3/scripts/download-actionlint.bash)
+          docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
 
       - name: "Check workflow files"
         run: |
           echo "::add-matcher::.github/workflows/matchers/actionlint.json"
-          ${{ steps.get_actionlint.outputs.executable }} -color
+          docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color


### PR DESCRIPTION
Manual dependency update. We also change to allow dependabot to update the actionlint version.