### PR TITLE
ci: Fix duplicate GitHub release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -113,6 +113,7 @@ jobs:
                   inputs: |
                       ./dist/*.tar.gz
                       ./dist/*.whl
+                  release-signing-artifacts: false
 
             - name: "Upload artifacts and signatures to GitHub release"
               run: |


### PR DESCRIPTION
sigstore/gh-action-sigstore-python 3.0 changed the default to now release to GitHub including the sigstore artifacts.

So we tell the action not to perform the release.