### PR TITLE
lint: Disable line length lint check

### DIFF
--- a/src/instructlab/schema/taxonomy.py
+++ b/src/instructlab/schema/taxonomy.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_TAXONOMY_FOLDERS: list[str] = ["compositional_skills", "knowledge"]
 """Taxonomy folders which are also the schema names"""
 
-DEFAULT_YAMLLINT_CONFIG: str = "{extends: relaxed, rules: {line-length: {max: 120}}}"
+DEFAULT_YAMLLINT_CONFIG: str = "{extends: relaxed, rules: {line-length: disable}}"
 """Default yamllint configuration"""
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -25,7 +25,7 @@ class TestParsingLogging:
         parser = TaxonomyParser(schema_version=0, message_format=TaxonomyMessageFormat.LOGGING)
         taxonomy = parser.parse(rel_path)
 
-        assert_that(taxonomy.warnings).is_greater_than_or_equal_to(1)
+        assert_that(taxonomy.warnings).is_zero()
         assert_that(taxonomy.errors).is_greater_than_or_equal_to(2)
         assert_that(taxonomy.path.as_posix()).is_equal_to(test_yaml)
         assert_that(taxonomy.rel_path).is_equal_to(rel_path)
@@ -33,10 +33,6 @@ class TestParsingLogging:
             "message",
             filter=self.message_filter(f"{re.escape(test_yaml)}:"),
         ).is_length(len(caplog.records))
-        assert_that(caplog.records).extracting(
-            "levelno",
-            filter=self.message_filter(r"line too long"),
-        ).contains_only(logging.WARNING)
         assert_that(caplog.records).extracting(
             "levelno",
             filter=self.message_filter(r"Unevaluated properties.*createdby"),
@@ -47,9 +43,15 @@ class TestParsingLogging:
         ).contains_only(logging.ERROR)
 
     def test_invalid_yamlint_strict(self, caplog: pytest.LogCaptureFixture, testdata: pathlib.Path) -> None:
+        yamllint_config = "{extends: relaxed, rules: {line-length: {max: 120}}}"
         test_yaml = "compositional_skills/invalid_yaml/qna.yaml"
         rel_path = testdata.joinpath(test_yaml)
-        parser = TaxonomyParser(schema_version=0, yamllint_strict=True, message_format=TaxonomyMessageFormat.LOGGING)
+        parser = TaxonomyParser(
+            schema_version=0,
+            message_format=TaxonomyMessageFormat.LOGGING,
+            yamllint_config=yamllint_config,
+            yamllint_strict=True,
+        )
         taxonomy = parser.parse(rel_path)
 
         assert_that(taxonomy.warnings).is_zero()
@@ -295,7 +297,7 @@ class TestParsingLogging:
         parser = TaxonomyParser(schema_version=2, message_format=TaxonomyMessageFormat.LOGGING)
         taxonomy = parser.parse(rel_path)
 
-        assert_that(taxonomy.warnings).is_greater_than_or_equal_to(1)
+        assert_that(taxonomy.warnings).is_zero()
         assert_that(taxonomy.errors).is_greater_than_or_equal_to(1)
         assert_that(taxonomy.path.as_posix()).is_equal_to(test_yaml)
         assert_that(taxonomy.rel_path).is_equal_to(rel_path)
@@ -304,10 +306,6 @@ class TestParsingLogging:
             "message",
             filter=self.message_filter(f"{re.escape(test_yaml)}:"),
         ).is_length(len(caplog.records))
-        assert_that(caplog.records).extracting(
-            "levelno",
-            filter=self.message_filter(r"line too long"),
-        ).contains_only(logging.WARNING)
         assert_that(caplog.records).extracting(
             "levelno",
             filter=self.message_filter(r"version.*required property"),
@@ -321,7 +319,7 @@ class TestParsingStdout:
         parser = TaxonomyParser(schema_version=0, message_format=TaxonomyMessageFormat.GITHUB)
         taxonomy = parser.parse(rel_path)
 
-        assert_that(taxonomy.warnings).is_greater_than_or_equal_to(1)
+        assert_that(taxonomy.warnings).is_zero()
         assert_that(taxonomy.errors).is_greater_than_or_equal_to(2)
         assert_that(taxonomy.path.as_posix()).is_equal_to(test_yaml)
         assert_that(taxonomy.rel_path).is_equal_to(rel_path)
@@ -340,7 +338,7 @@ class TestParsingStdout:
         parser = TaxonomyParser(schema_version=0, message_format=TaxonomyMessageFormat.STANDARD)
         taxonomy = parser.parse(rel_path)
 
-        assert_that(taxonomy.warnings).is_greater_than_or_equal_to(1)
+        assert_that(taxonomy.warnings).is_zero()
         assert_that(taxonomy.errors).is_greater_than_or_equal_to(2)
         assert_that(taxonomy.path.as_posix()).is_equal_to(test_yaml)
         assert_that(taxonomy.rel_path).is_equal_to(rel_path)
@@ -359,7 +357,7 @@ class TestParsingStdout:
         parser = TaxonomyParser(schema_version=0)
         taxonomy = parser.parse(rel_path)
 
-        assert_that(taxonomy.warnings).is_greater_than_or_equal_to(1)
+        assert_that(taxonomy.warnings).is_zero()
         assert_that(taxonomy.errors).is_greater_than_or_equal_to(2)
         assert_that(taxonomy.path.as_posix()).is_equal_to(test_yaml)
         assert_that(taxonomy.rel_path).is_equal_to(rel_path)


### PR DESCRIPTION
When using markdown tables in qna.yaml files, for example, in a knowledge context as copied from a source knowledge markdown file, the markdown table rows can be quite wide. Often much wider than the current 120 char line length limit. Since a markdown table row cannot be split without breaking the table, we need to disable line length checks to support the use of markdown tables in qna.yaml.