### PR TITLE
Separate CalledProcessError and FileNotFoundError exceptions

### DIFF
--- a/src/instructlab/schema/taxonomy.py
+++ b/src/instructlab/schema/taxonomy.py
@@ -330,11 +330,15 @@ class TaxonomyParser:
                         yq_expression = f"{yaml_path} | line"
                         line = subprocess.check_output(["yq", yq_expression], input=text, text=True)
                         line = line.strip() if line else 1
-                    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                        if isinstance(e, FileNotFoundError):
-                            self.yq_available = False
+                    except subprocess.CalledProcessError as e_yq:
                         logger.warning(
-                            "could not run yq command",
+                                f"Failed to validate file {taxonomy.path}, error: {e_yq}\n"
+                                f"Failed command: yq \"{yq_expression}\" {taxonomy.path}"
+                        )
+                    except FileNotFoundError as e:
+                        self.yq_available = False
+                        logger.warning(
+                            "Missing yq command, could not run yq command",
                             exc_info=True,
                         )
                 if validation_error.validator == "minItems":


### PR DESCRIPTION
Orginal logic does not make distinction between situation when:

1.  yq is missing, not installed, this problem is addressed here: https://github.com/instructlab/instructlab/pull/2796
2. when yq found a problem with the format and validation command failed

This commit separate scenario [1] and [2]. Also improve warning messages, allows user to re-run the yq command and help find a problem within qna.yaml file.