### PR TITLE
Fix `TaxonomyReadingException` message not displaying

### DIFF
--- a/src/instructlab/schema/taxonomy.py
+++ b/src/instructlab/schema/taxonomy.py
@@ -34,8 +34,11 @@ DEFAULT_YAMLLINT_CONFIG: str = "{extends: relaxed, rules: {line-length: disable}
 """Default yamllint configuration"""
 
 
+# pylint: disable=unnecessary-pass
 class TaxonomyReadingException(Exception):
     """An exception raised during reading of the taxonomy."""
+
+    pass
 
 
 class TaxonomyMessageFormat(enum.Enum):


### PR DESCRIPTION
Resolves #75 

To ensure the exception message gets printed, we need to either define an `__init__` function in the custom `TaxonomyReadingException` class OR add `pass`.

I opted for the latter approach and added unit tests to confirm the exception message gets printed/returned.